### PR TITLE
Auto-negotiate TLS version

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -6,7 +6,7 @@ import queue
 from netaddr import IPNetwork,IPRange
 
 def detect (ip,timeout,hostname) :
-    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     context.verify_mode = ssl.CERT_REQUIRED
     #context.check_hostname = True
     context.load_default_certs()

--- a/detect.py
+++ b/detect.py
@@ -8,23 +8,19 @@ from netaddr import IPNetwork,IPRange
 def detect (ip,timeout,hostname) :
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     context.verify_mode = ssl.CERT_REQUIRED
-    #context.check_hostname = True
+    context.check_hostname = True
     context.load_default_certs()
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.settimeout(timeout)
     ssl_sock = context.wrap_socket(s, server_hostname = hostname)
     try:
         ssl_sock.connect((ip, 443))#219.76.4.4 218.254.1.13
-        ca = str(ssl_sock.getpeercert())
-        ssl_sock.close()
-        s.close()
-        if ca.find(hostname) == -1:
-            return False
-        else:
-            return True
+        return True
     except:
         return False
-    return True
+    finally:
+        ssl_sock.close()
+        s.close()
 
 #print(detect("219.76.4.4",2))
 

--- a/sni-detecter.py
+++ b/sni-detecter.py
@@ -20,7 +20,7 @@ n = 0
 
 def main():
     try:
-        opts ,args = getopt.getopt(sys.argv[1:],'i:o:t:p:n:h',['in','out','timeout','parallels','hostname'])
+        opts ,args = getopt.getopt(sys.argv[1:],'i:o:t:p:n:h',['in=','out=','timeout=','parallels=','hostname=','help'])
     except getopt.GetoptError as err:
         usage()
         print(err)


### PR DESCRIPTION
调试的时候发现 TLS 版本不支持导致的报错，
```python3
[...]
  File "/home/tom/sni-detecter/detect.py", line 17, in detect
    ssl_sock.connect((ip, 443))
  File "/usr/lib/python3.9/ssl.py", line 1342, in connect
    self._real_connect(addr, False)
  File "/usr/lib/python3.9/ssl.py", line 1333, in _real_connect
    self.do_handshake()
  File "/usr/lib/python3.9/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:1123)
```
根据文档， [`ssl.PROTOCOL_TLSv1`](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLSv1) 是选择 TLS 1.0 版本，在目前看来是不安全的协议版本，故许多服务器不再支持，导致漏扫许多服务器。`ssl.PROTOCOL_TLSv1_1` 和 `ssl.PROTOCOL_TLSv1_2` 在 python 3.4 支持，[`ssl.PROTOCOL_TLS_CLIENT`](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT) 在 3.6 支持，让客户端自行选择能够支持的最高 TLS 版本在长期看来是个更好的选项。